### PR TITLE
Remove deprecated _all field when searching.

### DIFF
--- a/libraries/Elasticsearch/Helper/Index.php
+++ b/libraries/Elasticsearch/Helper/Index.php
@@ -143,7 +143,7 @@ class Elasticsearch_Helper_Index {
                         ]
                     ],
                     'files' => [
-                        'type' => 'nested',
+                        'type' => 'object',
                         'properties' => [
                             'id'      => ['type' => 'integer', 'index' => false],
                             'title'   => ['type' => 'keyword'],
@@ -158,7 +158,7 @@ class Elasticsearch_Helper_Index {
                         'fields' => ['keyword' => ['type' => 'keyword']]
                     ],
                     'blocks' => [
-                        'type' => 'nested',
+                        'type' => 'object',
                         'properties' => [
                             'text'        => ['type' => 'text'],
                             'attachments' => ['type' => 'text']
@@ -298,8 +298,7 @@ class Elasticsearch_Helper_Index {
             $must_query = [
                 'query_string' => [
                     'query' => $terms,
-                    'default_operator' => 'OR',
-                    'default_field' => '*'
+                    'default_operator' => 'OR'
                 ]
             ];
         }

--- a/libraries/Elasticsearch/Helper/Index.php
+++ b/libraries/Elasticsearch/Helper/Index.php
@@ -298,8 +298,8 @@ class Elasticsearch_Helper_Index {
             $must_query = [
                 'query_string' => [
                     'query' => $terms,
-                    'default_field' => '_all',
-                    'default_operator' => 'OR'
+                    'default_operator' => 'OR',
+                    'default_field' => '*'
                 ]
             ];
         }

--- a/libraries/Elasticsearch/Job/Reindex.php
+++ b/libraries/Elasticsearch/Job/Reindex.php
@@ -11,8 +11,13 @@ class Elasticsearch_Job_Reindex extends Omeka_Job_AbstractJob {
      * Main runnable method.
      */
     public function perform() {
-        Elasticsearch_Helper_Index::deleteIndex();
-        Elasticsearch_Helper_Index::createIndex();
-        Elasticsearch_Helper_Index::indexAll();
+        try {
+            Elasticsearch_Helper_Index::deleteIndex();
+            Elasticsearch_Helper_Index::createIndex();
+            Elasticsearch_Helper_Index::indexAll();
+        } catch(Exception $e) {
+            error_log("Error performing elasticsearch reindex job. Message: {$e->getMessage()}");
+            throw $e;
+        }
     }
 }


### PR DESCRIPTION
This PR removes the deprecated `_all` field for search queries due to it being deprecated in Elastic 6.2. Since Elastic 5.x defaults to `_all` when searching, omitting it should continue to work the same.  See #3.

Note that in the process of investigating this issue, we found that the search results seemed to differ slightly between 5.x and 6.2 with respect to searching nested documents. In 5.x, nested documents appear to be queried, where as in 6.x, they are not. Looking at the documentation for [default_field](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#_default_field), nested documents are not intended to be searchable by default, but instead must be searched by a _nested_ query. Since we want the nested objects to be searchable and it's OK if they are flattened, I've changed the mapping type to "object". This change returns the same results in Elastic 6.2 as it currently does in 5.6.