### PR TITLE
Support elements with multiple inputs

### DIFF
--- a/libraries/Elasticsearch/Helper/Index.php
+++ b/libraries/Elasticsearch/Helper/Index.php
@@ -138,8 +138,10 @@ class Elasticsearch_Helper_Index {
                     'elements'   => [
                         'type' => 'object',
                         'properties' => [
+                            'id'          => ['type' => 'integer', 'index' => false],
                             'displayName' => ['type' => 'keyword', 'index' => false],
-                            'name'        => ['type' => 'keyword', 'index' => false]
+                            'name'        => ['type' => 'keyword', 'index' => false],
+                            'text'        => ['type' => 'text', 'index' => false],
                         ]
                     ],
                     'files' => [

--- a/views/public/search/partials/results/item.php
+++ b/views/public/search/partials/results/item.php
@@ -15,12 +15,24 @@
 <?php endif; ?>
 
 <?php if(isset($hit['_source']['elements']) && isset($hit['_source']['element'])): ?>
-    <?php $elementText = $hit['_source']['element']; ?>
-    <?php $elementNames = $hit['_source']['elements']; ?>
-    <?php foreach($elementNames as $elementName): ?>
-        <?php if(isset($elementText[$elementName['name']])): ?>
-            <li title="element.<?php echo $elementName['name']; ?>"><b><?php echo $elementName['displayName']; ?>:</b> <?php echo $elementText[$elementName['name']]; ?></li>
-        <?php endif; ?>
+    <?php $elements = $hit['_source']['elements']; ?>
+    <?php foreach($elements as $element): ?>
+        <li class="elasticsearch-element" title="element.<?php echo $element['name']; ?>">
+            <b><?php echo $element['displayName']; ?>:</b>
+            <?php if(is_array($element['text'])): ?>
+                <?php if(count($element['text']) == 1): ?>
+                    <?php echo $element['text'][0]; ?>
+                <?php elseif(count($element['text']) > 1): ?>
+                    <ul class="elasticsearch-element-texts" >
+                    <?php foreach($element['text'] as $text): ?>
+                        <li><?php echo $text; ?></li>
+                    <?php endforeach; ?>
+                    </ul>
+                <?php endif; ?>
+            <?php else: ?>
+                <?php echo $element['text']; ?>
+            <?php endif; ?>
+        </li>
     <?php endforeach; ?>
 <?php endif; ?>
 

--- a/views/shared/css/elasticsearch-results.css
+++ b/views/shared/css/elasticsearch-results.css
@@ -8,6 +8,10 @@
     margin: 10px 0 0 0;
     padding: 0;
  }
+.elasticsearch-result ul ul {
+    list-style-type: circle;
+    margin: 0 0 0 25px;
+}
 .elasticsearch-result ul li {
     margin: 0 0 5px 0;
 }


### PR DESCRIPTION
This PR should resolve issue #6 so that elements having multiple inputs will be indexed and displayed properly. Previously, if there were multiple inputs for an element, only the last input would be used.

---

Here are a few screenshots showing the results of this PR:

**Omeka with a multi-valued subject element:**
![screen shot 2018-04-11 at 4 31 22 pm](https://user-images.githubusercontent.com/1165361/38642544-5c49a1b6-3da8-11e8-8f47-b3c53de8d420.png)

**Elasticsearch index data showing all input texts:**
![screen shot 2018-04-11 at 4 35 00 pm](https://user-images.githubusercontent.com/1165361/38642559-69e9e77c-3da8-11e8-9e3c-0a01ffbb0699.png)

**Omeka search result view showing all input texts:**
![screen shot 2018-04-11 at 4 33 59 pm](https://user-images.githubusercontent.com/1165361/38642554-629a704a-3da8-11e8-9928-2ed93663969e.png)